### PR TITLE
docs(anvil): add troubleshooting note for pending funding tx with automine disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,19 @@ cast block-number
 
 Run `anvil --help` to explore the full list of available features and their usage.
 
+### Troubleshooting: Chained transactions with automine disabled
+
+When **automine is off**, a second transaction that **depends on funds** created by a previous pending transaction may be rejected with:
+
+```
+error: Insufficient funds for gas * price + value
+```
+
+This happens because the second tx is validated **before** the funding tx is mined.  
+**Workarounds:**
+- Temporarily enable automine and mine the funding tx first, or
+- Manually mine a block between the two transactions.
+
 More documentation can be found in the [anvil](https://getfoundry.sh/anvil/overview) section of the Foundry Docs.
 
 ## Chisel


### PR DESCRIPTION
### Summary
This PR adds a troubleshooting note under the Anvil section, explaining the issue with chained transactions when `automine` is disabled and suggesting possible workarounds.

### Details
When `automine` is turned off, a second transaction that depends on funds created by a previous pending transaction may fail with the error:

```
error: Insufficient funds for gas * price + value
```

The note explains why this happens and provides two possible workarounds.

### Reference
Fixes part of the documentation gap mentioned in [#11239](https://github.com/foundry-rs/foundry/issues/11239).
